### PR TITLE
Fix issue: get hostname correctly

### DIFF
--- a/charms/osm/sshproxy.py
+++ b/charms/osm/sshproxy.py
@@ -161,7 +161,7 @@ class SSHProxy:
                 e.expected_key, e.got_key,
             )
         except (TimeoutError, socket.timeout):
-            stderr = "Timeout attempting to reach {}".format(cfg["ssh-hostname"])
+            stderr = "Timeout attempting to reach {}".format(self._get_hostname())
         except Exception as error:
             tb = traceback.format_exc()
             stderr = "Unhandled exception: {}".format(tb)


### PR DESCRIPTION
We were accessing the hostname from a variable that does not exist